### PR TITLE
Adapt to changes in Moo 2.004000

### DIFF
--- a/lib/Module/Manifest/Skip.pm
+++ b/lib/Module/Manifest/Skip.pm
@@ -28,9 +28,6 @@ sub import {
         close MS;
         exit;
     }
-    else {
-        goto &Moo::import;
-    }
 }
 
 sub add {


### PR DESCRIPTION
Moo-2.004000 refactored "creation and installation of helper subs" and
as a result a direct Moo::import execution stopped working and
Module-Manifest-Skip tests either:

t/create.t .............. Can't locate object method "_install_subs" via package "Module::Manifest::Skip" at /usr/share/perl5/vendor_perl/Moo.pm line 47.
BEGIN failed--compilation aborted at t/TestModuleManifestSkip.pm line 6.
Compilation failed in require at t/create.t line 3.

Because Moo::import() is already executed when Module::Manifest::Skip does "use
Moo;", the simplest fix is to stop calling it again.

https://github.com/ingydotnet/module-manifest-skip-pm/issues/7